### PR TITLE
Further improvement to the cursor: now, when invoked from the Menu an…

### DIFF
--- a/astrocook/gui_dialog.py
+++ b/astrocook/gui_dialog.py
@@ -1,6 +1,7 @@
+import astropy.units as au
 from .functions import elem_expand, meta_parse, trans_parse
 from .message import *
-from .vars import graph_elem, hwin_def
+from .vars import graph_elem, hwin_def, xem_d
 from collections import OrderedDict
 from copy import deepcopy as dc
 import inspect
@@ -616,12 +617,18 @@ class GUIDialogMiniSystems(GUIDialogMini):
                  title,
                  targ=None,
                  series='CIV',
-                 z=2.0,
+                 z=None,
                  hwin=hwin_def):
         self._gui = gui
         self._gui._dlg_mini_systems = self
         self._targ = targ
         self._series = series
+        if z is None:
+            try:
+                z = np.mean(self._gui._sess_sel.spec.t['x'].to(au.nm))\
+                        /xem_d['CIV_1548']-1
+            except:
+                z = 2.0
         self._z = z
         self._hwin = hwin
         super(GUIDialogMiniSystems, self).__init__(gui, title)

--- a/astrocook/gui_menu.py
+++ b/astrocook/gui_menu.py
@@ -141,7 +141,7 @@ class GUIMenu(object):
                         (event, title, targ)
                 gui_dlg_mini = getattr(self._gui, '_dlg_mini_'+dlg_mini)
                 gui_dlg_mini._shown = True
-                gui_dlg_mini._on_apply(event, refresh=False)
+                gui_dlg_mini._on_apply(event, refresh=True)
                 if dlg_mini == 'systems':
                     gui_dlg_mini._cursor_button.SetLabel("Hide cursor")
             else:


### PR DESCRIPTION
…d not from the System list, it is placed at the center of the available spectral range