### PR TITLE
PARTIAL - Fix Home button

### DIFF
--- a/astrocook/functions.py
+++ b/astrocook/functions.py
@@ -612,8 +612,27 @@ def x_convert(x, zem=0, xunit=au.km/au.s):
               lambda x: np.exp(x/ac.c.to(au.km/au.s).value)*xem.value)]
     return x.to(xunit, equivalencies=equiv)
 
-import functools
-import warnings
+def get_home_limits(stack_elements):
+    if len(stack_elements) > 0:
+        key = list(stack_elements[0].keys())[0]
+        return stack_elements[0][key][0]
+
+def update_home_limits(stack_elements, xlim = None, ylim = None):
+    if len(stack_elements) > 0:
+        key = list(stack_elements[0].keys())[0]
+        home_update_list = []
+        for _ in stack_elements[0][key]:
+            home_update_list.append(_)
+        if xlim is None and ylim is None:
+            return 
+        if ylim is None:
+            home_update_list[0] = (*xlim, *home_update_list[0][2:])
+        elif xlim is None:
+            home_update_list[0] = (*home_update_list[0][0:2], *ylim)
+        else:
+            home_update_list[0] = (*xlim, *ylim)
+        # Replace in the stack
+        stack_elements[0][key] = tuple(home_update_list)
 
 """
 @decorator

--- a/astrocook/gui_graph.py
+++ b/astrocook/gui_graph.py
@@ -1,4 +1,4 @@
-from .functions import elem_expand
+from .functions import elem_expand, update_home_limits
 from .graph import Graph
 from .gui_dialog import * #GUIDialogMini
 from .syst_list import SystList
@@ -71,6 +71,7 @@ class GUIGraphMain(wx.Frame):
         self._panel.SetSizer(self._box)
         self.Centre()
         self.Bind(wx.EVT_CLOSE, self._on_close)
+        self._home_limits = {}
         #self._graph._toolbar.wx_ids['Home'] = self._home
 
         #self._gui._statusbar = self.CreateStatusBar()
@@ -86,6 +87,19 @@ class GUIGraphMain(wx.Frame):
         self._graph._refresh(sess, self._logx, self._logy, self._norm,
                              self._legend, **kwargs)
         self._refreshed = True
+        
+        update_xlim = self._gui._graph_main._graph._ax.get_xlim()
+        update_ylim = self._gui._graph_main._graph._ax.get_ylim()
+        
+        stack_elems = self._gui._graph_main._graph._toolbar._nav_stack._elements
+        if self._gui._sess_item_sel == []:
+            sess_id = 0
+        else:
+            sess_id = self._gui._sess_item_sel[0]
+        if not self._gui._graph_main._graph._zoom:
+            self._home_limits[sess_id] = (update_xlim, update_ylim)
+
+        update_home_limits(stack_elems, xlim=self._home_limits[sess_id][0], ylim=self._home_limits[sess_id][1])
         self.Show()
 
     #def _on_line_new(self, event):

--- a/astrocook/gui_graph.py
+++ b/astrocook/gui_graph.py
@@ -102,9 +102,6 @@ class GUIGraphMain(wx.Frame):
         update_home_limits(stack_elems, xlim=self._home_limits[sess_id][0], ylim=self._home_limits[sess_id][1])
         self.Show()
 
-    #def _on_line_new(self, event):
-    #    print(self._click_xy)
-
 
     def _on_bin_zap(self, event):
         sess = self._gui._sess_sel


### PR DESCRIPTION
How to reproduce:
1 - Do something in the plot window (such as panning), and convert the coordinates to other units. By pressing the "home" button, the x-axis will be completely out of sync with the position of the data.

Notes:
1 - For the problem to occur, there must have been at least one action that modifies the plot (such as zooming in/out or panning). Only after one of these actions matplotlib starts to build the history of what has been done in the plot.
2 - The session in which the FIRST action is taken is important! Just before the first action, matplotlib essentially saves the result of ax.get_xlim() and ax.get_ylim() for the active session. These are the values it returns when you press home.

Origin of the problem (as far as I understand):
- Matplotlib has a "stack" that functions as a history of what has happened in a plot
- Every time an action is taken (such as moving the plot, zooming in/out), matplotlib adds the action to the end of the stack. - By pressing the home button, matplotlib goes back to the beginning of the stack.
- As far as I understand (but it's better to test this point thoroughly), the list of actions is created immediately, but it is initially empty. The initial state is saved only after the first action is taken.
- Mpl saves the coordinates, and is not aware of the units of these coordinates -> after converting the wavelength, our mental 'home' does not match matplotlib's

Extra information possibly useful for the fix:
- The home button is part of a toolbar. All backends inherit from backend_base and, for the home button, call _update_view (https://stackoverflow.com/a/71047203)
- The stack list can be accessed directly using toolbar._nav_stack._elements (https://stackoverflow.com/a/63152341)

Solution (incomplete):
get the limits for the main plot window during the refresh, and update the zeroth element of stack per session

When it works (or at least seems to work):
- Main window
- The update seems to work both with one or more sessions

When it doesn't work:
- Details window, everything breaks (might not be related? Needs more testing)

Not tested:
- Everything else

Let me know if you need more details!