### PR TITLE
Dialogue window stays after stick cursor

### DIFF
--- a/astrocook/gui_graph.py
+++ b/astrocook/gui_graph.py
@@ -102,7 +102,6 @@ class GUIGraphMain(wx.Frame):
 
     def _on_cursor_stick(self, event=None, cursor_z=None):
         sess = self._gui._sess_sel
-        #print(self._graph._cursor._z * sess.spec._rfz)
         z = "%2.6f" % (self._graph._cursor._z*(1+sess.spec._rfz))
 
         if not hasattr(sess, '_cursors'):
@@ -115,11 +114,7 @@ class GUIGraphMain(wx.Frame):
         self._elem = sess._graph_elem
 
         self._gui._refresh()
-        """
-        if hasattr(self._gui, '_dlg_mini_graph'):
-            self._gui._dlg_mini_graph._refresh()
-        self._refresh(sess)
-        """
+
         if hasattr(self._gui, '_dlg_mini_systems'):
             # Unfreeze cursors in case they were frozen
             self._gui._graph_main._graph._cursor_frozen = False
@@ -127,10 +122,7 @@ class GUIGraphMain(wx.Frame):
                 self._gui._graph_det._graph._cursor_frozen = False
 
             # Refresh cursor
-            self._gui._dlg_mini_systems._shown = False
-            self._gui._dlg_mini_systems._on_cancel(e=None)
-            self._gui._dlg_mini_systems._shown = True
-            self._gui._dlg_mini_systems._on_apply(e=None)
+            self._gui._dlg_mini_systems._cursor_refresh()
 
     def _on_node_add(self, event):
         sess = self._gui._sess_sel


### PR DESCRIPTION
Should fix #306. The changes are limited to `_on_cursor_stick`, so chances to break something major are slim, and it seems to work in the brief test session I tried :)