### PR TITLE
(Possibly partial) fix for #332

### DIFF
--- a/astrocook/cookbook_absorbers.py
+++ b/astrocook/cookbook_absorbers.py
@@ -447,7 +447,7 @@ class CookbookAbsorbers(object):
                                 id_check = ''
                             ids = [str(id) for id in systs_t['id']]+['']
 
-                            if v[2]!=None and id_check in ids:
+                            if v[2] is not None and id_check in ids:
                                 constr[k] = v[2]
                             else:
                                 vars[k.split('_')[-1]+'_vary'] = False

--- a/astrocook/format.py
+++ b/astrocook/format.py
@@ -129,10 +129,17 @@ class Format(object):
                 if 'CONSTR' in ks:
                     id_check = 'AC CONSTR ID '+ks[-1]
                     if 'id' in out._t.colnames and hdr[id_check] in out._t['id']:
-                        if 'ID' in ks: id = int(hdr[k])
-                        if 'PAR' in ks: par = hdr[k]
-                        if 'VAL' in ks: out._constr['lines_voigt_%i_%s' % (id,par)] \
-                            = (id, par, hdr[k])
+                        if 'ID' in ks:
+                            id = int(hdr[k])
+
+                        if 'PAR' in ks:
+                            par = hdr[k]
+
+                        if 'VAL' in ks:
+                            # Why are there duplicates in the saved file though?
+                            new_key = 'lines_voigt_%i_%s' % (id, par)
+                            if new_key not in out._constr:
+                                out._constr[new_key] = (id, par, hdr[k])
         return out
 
 

--- a/astrocook/format.py
+++ b/astrocook/format.py
@@ -138,7 +138,10 @@ class Format(object):
                         if 'VAL' in ks:
                             # Why are there duplicates in the saved file though?
                             new_key = 'lines_voigt_%i_%s' % (id, par)
-                            if new_key not in out._constr:
+                            # we don't know what is the right key saved unfortunately
+                            #  so we update with anything that is not None
+                            # or, worse case scenario, with None
+                            if (new_key not in out._constr) or (hdr[k] is not None):
                                 out._constr[new_key] = (id, par, hdr[k])
         return out
 

--- a/astrocook/functions.py
+++ b/astrocook/functions.py
@@ -622,37 +622,3 @@ def x_convert(x, zem=0, xunit=au.km/au.s):
               lambda x: np.log(x/xem.value)*ac.c.to(au.km/au.s),
               lambda x: np.exp(x/ac.c.to(au.km/au.s).value)*xem.value)]
     return x.to(xunit, equivalencies=equiv)
-
-import functools
-import warnings
-
-"""
-@decorator
-class arg_fix:
-    #Decorator ensuring backward compatibility when an argument name is
-    #modified in a function definition.
-    #from https://gist.github.com/rfezzani/002181c8667ec4c671421a4d938167eb
-
-    def __init__(self, arg_mapping):
-        #Args:
-        #    arg_mapping (dict): mapping between the function's old argument
-        #        names and the new ones.
-        self.arg_mapping = arg_mapping
-        self.warning_msg = ("'%s' is a deprecated argument name " +
-                            "for the function '%s', use '%s' instead.")
-
-    def __call__(self, f):
-        @functools.wraps(f)
-        def fixed_f(*args, **kwargs):
-            for old_arg, new_arg in self.arg_mapping.items():
-                if old_arg in kwargs:
-                    #  warn that the function interface has changed:
-                    warnings.warn(self.warning_msg %
-                        (old_arg, f.__name__, new_arg), DeprecationWarning)
-                    # Substitute new_arg to old_arg
-                    kwargs[new_arg] = kwargs.pop(old_arg)
-
-            # Call the function with the fixed arguments
-            return f(*args, **kwargs)
-        return fixed_f
-"""

--- a/astrocook/gui_table.py
+++ b/astrocook/gui_table.py
@@ -274,6 +274,10 @@ class GUITable(wx.Frame):
     def _view(self, event=None, from_scratch=True, autosort=False):
         self._data_init(from_scratch, autosort)
         self._box = wx.BoxSizer(wx.VERTICAL)
+        # Thanks ChatGPT
+        if self._tab.GetContainingSizer():
+            self._tab.GetContainingSizer().Detach(self._tab)
+
         self._box.Add(self._tab, 1, wx.EXPAND)
         self._panel.SetSizer(self._box)
         self._tab.Bind(wx.grid.EVT_GRID_CELL_CHANGED, self._on_edit)

--- a/astrocook/session.py
+++ b/astrocook/session.py
@@ -666,6 +666,12 @@ class Session(object):
                                     t.meta['HIERARCH AC CONSTR ID %i' % i] = v[0]
                                     t.meta['HIERARCH AC CONSTR PAR %i' % i] = v[1]
                                     t.meta['HIERARCH AC CONSTR VAL %i' % i] = v[2]
+
+                        # Make sure that for each id there is only one constrain
+                        # Can't do this: the same redshift, say, can be tied to multiple different things
+                        #  so this might actually erase some constraints previously set
+                        # Question remains as to why there were two sets of equivalent constraints, one with 
+                        #  something, the other with just `None`s
                         for c in t.colnames:
                             t[c].unit = au.dimensionless_unscaled
                         #print(t)


### PR DESCRIPTION
Possible fix for #332. At least in one case, the problem appears to be due to the saved metadata in the fits header (packed in the acs archive). They contain a duplicate set of constraints, one with "good data" and one where every constrain is `None`. Unclear why this is the case as of now, I will have a look but I am not entirely sure where to even start on this one.

Also fix a visual bug that made it seem like there were no constraints in the system table, while on the other hand constraints were set (thanks ChatGPT for that one).\

As always, @gcupani let me know!